### PR TITLE
SRE-5394 : report redis connection errors 

### DIFF
--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	ShadowRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rate_limiting_shadow_requests",
+		Help: "The total number of requests that would of been rate limited not in shadow mode",
+	}, []string{"descriptor_key", "descriptor_value", "limit", "unit"})
+	LimitedRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rate_limiting_limited_requests",
+		Help: "The total number of requests that have been rate limited",
+	}, []string{"descriptor_key", "descriptor_value", "limit", "unit"})
+	RateLimitRequestSummary = promauto.NewSummary(prometheus.SummaryOpts{
+		Name:       "rate_limiting_request_time_sec",
+		Help:       "Summary of rate limiting request times",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	RateLimitErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rate_limiting_service_errors",
+		Help: "Count of different rate limiting errors",
+	}, []string{"type"})
+)

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mediocregopher/radix/v3/trace"
-
 	stats "github.com/lyft/gostats"
 	"github.com/mediocregopher/radix/v3"
+	"github.com/mediocregopher/radix/v3/trace"
+	"github.com/replicon/ratelimit/src/metrics"
 	logger "github.com/sirupsen/logrus"
 )
 
@@ -75,8 +75,7 @@ func NewClientImpl(scope stats.Scope, useTls bool, auth string, url string, pool
 		conn, err := radix.Dial(network, addr, dialOpts...)
 		if err != nil {
 			logger.Errorf("error connecting to redis instance: %s", err.Error())
-			
-			
+			metrics.RateLimitErrors.WithLabelValues("redis_connection").Inc()
 		}
 		return conn, err
 	}

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -72,7 +72,13 @@ func NewClientImpl(scope stats.Scope, useTls bool, auth string, url string, pool
 			dialOpts = append(dialOpts, radix.DialAuthPass(auth))
 		}
 
-		return radix.Dial(network, addr, dialOpts...)
+		conn, err := radix.Dial(network, addr, dialOpts...)
+		if err != nil {
+			logger.Errorf("error connecting to redis instance: %s", err.Error())
+			
+			
+		}
+		return conn, err
 	}
 
 	stats := newPoolStats(scope)

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -178,7 +178,7 @@ func (this *service) ShouldRateLimit(
 			return
 		}
 
-		logger.Debugf("caught error during call")
+		logger.Errorf("caught error during call")
 		finalResponse = nil
 		switch t := err.(type) {
 		case redis.RedisError:


### PR DESCRIPTION
Test Plan:

Deployed to dynamic swimlane and killed redis. Observed the expected metric increase in count and an alert was triggered [x]
Ensured that fixing redis allowed this alert to clear on its own [x]
Confirmed that error appears under rate limiting errors in grafana [x]

Previously we would not have had visibility into this 