### PR TITLE
SRE-5202 : add per rule shadow mode setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ compile:
 	go build -mod=readonly -o ./bin/ratelimit_client $(MODULE)/src/client_cmd
 	go build -mod=readonly -o ./bin/ratelimit_config_check $(MODULE)/src/config_check_cmd
 
+.PHONY: tests_unit_no_cache
+tests_unit_no_cache: compile
+	go test -count=1 -race $(MODULE)/...
+
 .PHONY: tests_unit
 tests_unit: compile
 	go test -race $(MODULE)/...

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -29,9 +29,10 @@ type RateLimitStats struct {
 
 // Wrapper for an individual rate limit config entry which includes the defined limit and stats.
 type RateLimit struct {
-	FullKey string
-	Stats   RateLimitStats
-	Limit   *pb.RateLimitResponse_RateLimit
+	FullKey    string
+	Stats      RateLimitStats
+	Limit      *pb.RateLimitResponse_RateLimit
+	ShadowMode bool
 }
 
 // Interface for interacting with a loaded rate limit config.

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -184,8 +184,9 @@ func validateYamlKeys(config RateLimitConfigToLoad, config_map map[interface{}]i
 		case map[interface{}]interface{}:
 			validateYamlKeys(config, v)
 		// string is a leaf type in ratelimit config. No need to keep validating.
-		case bool:
 		case string:
+		// bool is a leaf type in ratelimit config. No need to keep validating.
+		case bool:
 		// int is a leaf type in ratelimit config. No need to keep validating.
 		case int:
 		// nil case is an incorrectly formed yaml. However, because this function's purpose is to validate
@@ -270,8 +271,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 	}
 
 	if descriptor.GetLimit() != nil {
-		//TODO: Eval when this is actually called and how it impacts setting this to false always
-		logger.Info("Get limit called without context. Shadow mode is disabled now")
+		logger.Info("get limit called without context. Shadow mode is disabled for this rate limit")
 		rateLimitKey := domain + "." + this.descriptorToKey(descriptor)
 		rateLimitOverrideUnit := pb.RateLimitResponse_RateLimit_Unit(descriptor.GetLimit().GetUnit())
 		rateLimit = NewRateLimit(

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -184,6 +184,7 @@ func validateYamlKeys(config RateLimitConfigToLoad, config_map map[interface{}]i
 		case map[interface{}]interface{}:
 			validateYamlKeys(config, v)
 		// string is a leaf type in ratelimit config. No need to keep validating.
+		case bool:
 		case string:
 		// int is a leaf type in ratelimit config. No need to keep validating.
 		case int:

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -271,7 +271,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 	}
 
 	if descriptor.GetLimit() != nil {
-		logger.Info("get limit called without context. Shadow mode is disabled for this rate limit")
+		// This should only be called when envoy provides a rate limit override. Shadow mode will default to false in this case
 		rateLimitKey := domain + "." + this.descriptorToKey(descriptor)
 		rateLimitOverrideUnit := pb.RateLimitResponse_RateLimit_Unit(descriptor.GetLimit().GetUnit())
 		rateLimit = NewRateLimit(

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -52,6 +52,7 @@ var validKeys = map[string]bool{
 	"rate_limit":        true,
 	"unit":              true,
 	"requests_per_unit": true,
+	"shadowmode":        true,
 }
 
 // Create new rate limit stats for a config entry.

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -271,6 +271,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 
 	if descriptor.GetLimit() != nil {
 		//TODO: Eval when this is actually called and how it impacts setting this to false always
+		logger.Info("Get limit called without context. Shadow mode is disabled now")
 		rateLimitKey := domain + "." + this.descriptorToKey(descriptor)
 		rateLimitOverrideUnit := pb.RateLimitResponse_RateLimit_Unit(descriptor.GetLimit().GetUnit())
 		rateLimit = NewRateLimit(

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -138,12 +138,10 @@ func (this *rateLimitCacheImpl) DoLimit(
 				LimitRemaining: 0,
 			}
 			if limits[i].ShadowMode {
-				//TODO: add metrics
-				logger.Info("Would of rate limited ", cacheKey.Key, " but shadow mode is enabled")
-				kvMeta := util.GetDescriptorKV(status, request.Descriptors[i])
+				logger.Debugf("Would of rate limited %s but shadow mode is enabled on this rule", cacheKey.Key)
+				metricsDescriptor := util.ConvertToMetricsDescriptor(status, request.Descriptors[i])
 
-				labels := map[string]string{"descriptor_key": kvMeta.Key, "descriptor_value": kvMeta.Value, "limit": kvMeta.Limit, "unit": kvMeta.Unit}
-				logger.Info(labels)
+				labels := map[string]string{"descriptor_key": metricsDescriptor.Key, "descriptor_value": metricsDescriptor.Value, "limit": metricsDescriptor.Limit, "unit": metricsDescriptor.Unit}
 				metrics.ShadowRequests.With(labels).Inc()
 
 				status.Code = pb.RateLimitResponse_OK
@@ -170,12 +168,10 @@ func (this *rateLimitCacheImpl) DoLimit(
 				LimitRemaining: 0,
 			}
 			if limits[i].ShadowMode {
-				//TODO: add metrics
-				logger.Info("Would of rate limited", cacheKey.Key, " but shadow mode is enabled")
-				kvMeta := util.GetDescriptorKV(status, request.Descriptors[i])
+				logger.Debugf("Would of rate limited %s but shadow mode is enabled", cacheKey.Key)
+				metricsDescriptor := util.ConvertToMetricsDescriptor(status, request.Descriptors[i])
 
-				labels := map[string]string{"descriptor_key": kvMeta.Key, "descriptor_value": kvMeta.Value, "limit": kvMeta.Limit, "unit": kvMeta.Unit}
-				logger.Info(labels)
+				labels := map[string]string{"descriptor_key": metricsDescriptor.Key, "descriptor_value": metricsDescriptor.Value, "limit": metricsDescriptor.Limit, "unit": metricsDescriptor.Unit}
 				metrics.ShadowRequests.With(labels).Inc()
 				status.Code = pb.RateLimitResponse_OK
 			}

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -130,9 +130,15 @@ func (this *rateLimitCacheImpl) DoLimit(
 		}
 
 		if isOverLimitWithLocalCache[i] {
+			status := pb.RateLimitResponse_OVER_LIMIT
+			if limits[i].ShadowMode {
+				//TODO: add metrics
+				logger.Info("Would of rate limited", cacheKey.Key, " but shadow mode is enabled")
+				status = pb.RateLimitResponse_OK
+			}
 			responseDescriptorStatuses[i] =
 				&pb.RateLimitResponse_DescriptorStatus{
-					Code:           pb.RateLimitResponse_OVER_LIMIT,
+					Code:           status,
 					CurrentLimit:   limits[i].Limit,
 					LimitRemaining: 0,
 				}
@@ -150,9 +156,15 @@ func (this *rateLimitCacheImpl) DoLimit(
 
 		logger.Debugf("cache key: %s current: %d", cacheKey.Key, limitAfterIncrease)
 		if limitAfterIncrease > overLimitThreshold {
+			status := pb.RateLimitResponse_OVER_LIMIT
+			if limits[i].ShadowMode {
+				//TODO: add metrics
+				logger.Info("Would of rate limited", cacheKey.Key, " but shadow mode is enabled")
+				status = pb.RateLimitResponse_OK
+			}
 			responseDescriptorStatuses[i] =
 				&pb.RateLimitResponse_DescriptorStatus{
-					Code:           pb.RateLimitResponse_OVER_LIMIT,
+					Code:           status,
 					CurrentLimit:   limits[i].Limit,
 					LimitRemaining: 0,
 				}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -179,11 +179,10 @@ func (this *service) ShouldRateLimit(
 	response := this.shouldRateLimitWorker(ctx, request)
 	if response.OverallCode != pb.RateLimitResponse_OK {
 		for i, descriptorStatus := range response.Statuses {
-			//per rule shadow mode will change this metric since the Code will be OK even if we have
 			if descriptorStatus.Code == pb.RateLimitResponse_OVER_LIMIT {
 				descriptor := request.Descriptors[i]
-				kvMeta := util.GetDescriptorKV(descriptorStatus, descriptor)
-				labels := map[string]string{"descriptor_key": kvMeta.Key, "descriptor_value": kvMeta.Value, "limit": kvMeta.Limit, "unit": kvMeta.Unit}
+				metricsDescriptor := util.ConvertToMetricsDescriptor(descriptorStatus, descriptor)
+				labels := map[string]string{"descriptor_key": metricsDescriptor.Key, "descriptor_value": metricsDescriptor.Value, "limit": metricsDescriptor.Limit, "unit": metricsDescriptor.Unit}
 				if this.shadowMode {
 					metrics.ShadowRequests.With(labels).Inc()
 				} else {

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -9,14 +9,14 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 )
 
-type KVDesc struct {
+type MetricsDescriptor struct {
 	Limit string
 	Unit  string
 	Key   string
 	Value string
 }
 
-func GetDescriptorKV(descriptorStatus *pb.RateLimitResponse_DescriptorStatus, descriptor *envoy_extensions_common_ratelimit_v3.RateLimitDescriptor) KVDesc {
+func ConvertToMetricsDescriptor(descriptorStatus *pb.RateLimitResponse_DescriptorStatus, descriptor *envoy_extensions_common_ratelimit_v3.RateLimitDescriptor) MetricsDescriptor {
 	var descriptorKey strings.Builder
 	var descriptorValue strings.Builder
 	limit := ""
@@ -37,7 +37,7 @@ func GetDescriptorKV(descriptorStatus *pb.RateLimitResponse_DescriptorStatus, de
 		unit = descriptorStatus.CurrentLimit.Unit.String()
 	}
 
-	return KVDesc{
+	return MetricsDescriptor{
 		Unit:  unit,
 		Limit: limit,
 		Key:   descriptorKey.String(),

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	envoy_extensions_common_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+)
+
+type KVDesc struct {
+	Limit string
+	Unit  string
+	Key   string
+	Value string
+}
+
+func GetDescriptorKV(descriptorStatus *pb.RateLimitResponse_DescriptorStatus, descriptor *envoy_extensions_common_ratelimit_v3.RateLimitDescriptor) KVDesc {
+	var descriptorKey strings.Builder
+	var descriptorValue strings.Builder
+	limit := ""
+	unit := ""
+
+	for _, entry := range descriptor.Entries {
+		if descriptorKey.Len() != 0 {
+			descriptorKey.WriteString("_")
+		}
+		if descriptorValue.Len() != 0 {
+			descriptorValue.WriteString("_")
+		}
+		descriptorKey.WriteString(entry.Key)
+		descriptorValue.WriteString(fmt.Sprintf("%.*s", 40, entry.Value))
+	}
+	if descriptorStatus.CurrentLimit != nil {
+		limit = strconv.FormatUint(uint64(descriptorStatus.CurrentLimit.RequestsPerUnit), 10)
+		unit = descriptorStatus.CurrentLimit.Unit.String()
+	}
+
+	return KVDesc{
+		Unit:  unit,
+		Limit: limit,
+		Key:   descriptorKey.String(),
+		Value: descriptorValue.String(),
+	}
+}

--- a/test/config/shadowmode_config.yaml
+++ b/test/config/shadowmode_config.yaml
@@ -1,0 +1,59 @@
+# Basic configuration for testing.
+domain: test-domain
+descriptors:
+  # Top level key/value with no default rate limit.
+  - key: key1
+    value: value1
+    descriptors:
+      # 2nd level key only with default rate limit.
+      - key: subkey1
+        rate_limit:
+          unit: second
+          requests_per_unit: 5
+        shadowmode: true
+
+      # 2nd level key/value with limit. Specific override at 2nd level.
+      - key: subkey1
+        value: subvalue1
+        rate_limit:
+          unit: second
+          requests_per_unit: 10
+
+  # Top level key only with default rate limit.
+  - key: key2
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+    shadowmode: true
+  # Top level key/value with limit. Specific override at 1st level.
+  - key: key2
+    value: value2
+    rate_limit:
+      unit: minute
+      requests_per_unit: 30
+
+  # First level override with no limit. This effectively whitelists the value.
+  - key: key2
+    value: value3
+
+  - key: key3
+    rate_limit:
+      unit: hour
+      requests_per_unit: 1
+
+  - key: key4
+    rate_limit:
+      unit: day
+      requests_per_unit: 1
+
+  - key: key5
+    value: value5
+    rate_limit:
+      unit: day
+      requests_per_unit: 15
+    descriptors:
+      - key: subkey5
+        value: subvalue5
+        rate_limit:
+          unit: day
+          requests_per_unit: 25

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -46,7 +46,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 
 			cache := redis.NewRateLimitCacheImpl(client, nil, limiter.NewTimeSourceImpl(), rand.New(limiter.NewLockedSource(time.Now().Unix())), 10, nil)
 			request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
-			limits := []*config.RateLimit{config.NewRateLimit(1000000000, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
+			limits := []*config.RateLimit{config.NewRateLimit(1000000000, pb.RateLimitResponse_RateLimit_SECOND, "key_value", false, statsStore)}
 
 			// wait for the pool to fill up
 			for {

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -62,7 +62,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		clientUsed.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 		request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
-		limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
+		limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", false, statsStore)}
 
 		assert.Equal(
 			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}},
@@ -86,7 +86,7 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 			}, 1)
 		limits = []*config.RateLimit{
 			nil,
-			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key2_value2_subkey2_subvalue2", statsStore)}
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key2_value2_subkey2_subvalue2", false, statsStore)}
 		assert.Equal(
 			[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}},
@@ -112,8 +112,8 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 				{{"key3", "value3"}, {"subkey3", "subvalue3"}},
 			}, 1)
 		limits = []*config.RateLimit{
-			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, "key3_value3", statsStore),
-			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_DAY, "key3_value3_subkey3_subvalue3", statsStore)}
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, "key3_value3", false, statsStore),
+			config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_DAY, "key3_value3_subkey3_subvalue3", false, statsStore)}
 		assert.Equal(
 			[]*pb.RateLimitResponse_DescriptorStatus{
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
@@ -187,7 +187,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
 
 	limits := []*config.RateLimit{
-		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", statsStore)}
+		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
@@ -277,7 +277,7 @@ func TestNearLimit(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 1)
 
 	limits := []*config.RateLimit{
-		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", statsStore)}
+		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, "key4_value4", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{
@@ -326,7 +326,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key5", "value5"}}}, 3)
-	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key5_value5", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key5_value5", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 15}},
@@ -342,7 +342,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key6", "value6"}}}, 2)
-	limits = []*config.RateLimit{config.NewRateLimit(8, pb.RateLimitResponse_RateLimit_SECOND, "key6_value6", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(8, pb.RateLimitResponse_RateLimit_SECOND, "key6_value6", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}},
@@ -358,7 +358,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key7", "value7"}}}, 3)
-	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key7_value7", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key7_value7", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}},
@@ -374,7 +374,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key8", "value8"}}}, 3)
-	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key8_value8", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key8_value8", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}},
@@ -390,7 +390,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key9", "value9"}}}, 7)
-	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key9_value9", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(20, pb.RateLimitResponse_RateLimit_SECOND, "key9_value9", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}},
@@ -406,7 +406,7 @@ func TestNearLimit(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request = common.NewRateLimitRequest("domain", [][][2]string{{{"key10", "value10"}}}, 3)
-	limits = []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key10_value10", statsStore)}
+	limits = []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key10_value10", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}},
@@ -434,7 +434,7 @@ func TestRedisWithJitter(t *testing.T) {
 	client.EXPECT().PipeDo(gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
-	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", false, statsStore)}
 
 	assert.Equal(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}},

--- a/test/service/ratelimit_legacy_test.go
+++ b/test/service/ratelimit_legacy_test.go
@@ -93,7 +93,7 @@ func TestServiceLegacy(test *testing.T) {
 	}
 
 	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore),
 		nil}
 	legacyLimits, err := convertRatelimits(limits)
 	if err != nil {
@@ -130,7 +130,7 @@ func TestServiceLegacy(test *testing.T) {
 	// Config should still be valid. Also make sure order does not affect results.
 	limits = []*config.RateLimit{
 		nil,
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore)}
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore)}
 	legacyLimits, err = convertRatelimits(limits)
 	if err != nil {
 		t.assert.FailNow(err.Error())
@@ -193,7 +193,7 @@ func TestCacheErrorLegacy(test *testing.T) {
 	if err != nil {
 		t.assert.FailNow(err.Error())
 	}
-	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore)}
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore)}
 	t.config.EXPECT().GetLimit(nil, "different-domain", req.Descriptors[0]).Return(limits[0])
 	t.cache.EXPECT().DoLimit(nil, req, limits).Do(
 		func(context.Context, *pb.RateLimitRequest, []*config.RateLimit) {

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -171,6 +171,7 @@ func TestService(test *testing.T) {
 	t.assert.EqualValues(1, t.statStore.NewCounter("config_load_error").Value())
 }
 func TestShadowMode(test *testing.T) {
+	test.Skip()
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService(true)
@@ -178,7 +179,7 @@ func TestShadowMode(test *testing.T) {
 	request := common.NewRateLimitRequest(
 		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
 	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", true, t.statStore),
 		nil}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -117,7 +117,7 @@ func TestService(test *testing.T) {
 	request = common.NewRateLimitRequest(
 		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
 	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore),
 		nil}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
@@ -149,7 +149,7 @@ func TestService(test *testing.T) {
 	// Config should still be valid. Also make sure order does not affect results.
 	limits = []*config.RateLimit{
 		nil,
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore)}
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore)}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
 	t.cache.EXPECT().DoLimit(nil, request, limits).Return(
@@ -178,7 +178,7 @@ func TestShadowMode(test *testing.T) {
 	request := common.NewRateLimitRequest(
 		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
 	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore),
 		nil}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
@@ -226,7 +226,7 @@ func TestCacheError(test *testing.T) {
 	service := t.setupBasicService(false)
 
 	request := common.NewRateLimitRequest("different-domain", [][][2]string{{{"foo", "bar"}}}, 1)
-	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", t.statStore)}
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore)}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.cache.EXPECT().DoLimit(nil, request, limits).Do(
 		func(context.Context, *pb.RateLimitRequest, []*config.RateLimit) {

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -170,8 +170,7 @@ func TestService(test *testing.T) {
 	t.assert.EqualValues(2, t.statStore.NewCounter("config_load_success").Value())
 	t.assert.EqualValues(1, t.statStore.NewCounter("config_load_error").Value())
 }
-func TestShadowMode(test *testing.T) {
-	test.Skip()
+func TestGlobalShadowMode(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService(true)
@@ -179,7 +178,7 @@ func TestShadowMode(test *testing.T) {
 	request := common.NewRateLimitRequest(
 		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
 	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", true, t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore),
 		nil}
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
@@ -192,6 +191,65 @@ func TestShadowMode(test *testing.T) {
 			OverallCode: pb.RateLimitResponse_OK,
 			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: nil, LimitRemaining: 0},
+			}},
+		response)
+	t.assert.Nil(err)
+}
+
+func TestRuleShadowMode(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService(false)
+
+	request := common.NewRateLimitRequest(
+		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", true, t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", true, t.statStore)}
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
+	t.cache.EXPECT().DoLimit(nil, request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}})
+	response, err := service.ShouldRateLimit(nil, request)
+	t.assert.Equal(
+		&pb.RateLimitResponse{
+			OverallCode: pb.RateLimitResponse_OK,
+			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+				{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+			}},
+		response)
+	t.assert.Nil(err)
+}
+func TestMixedRuleShadowMode(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService(false)
+
+	request := common.NewRateLimitRequest(
+		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", true, t.statStore),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, "key", false, t.statStore)}
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
+	testResults := []pb.RateLimitResponse_Code{pb.RateLimitResponse_OVER_LIMIT, pb.RateLimitResponse_OVER_LIMIT}
+	for i := 0; i < len(limits); i++ {
+		if limits[i].ShadowMode {
+			testResults[i] = pb.RateLimitResponse_OK
+		}
+	}
+	t.cache.EXPECT().DoLimit(nil, request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: testResults[0], CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+			{Code: testResults[1], CurrentLimit: nil, LimitRemaining: 0}})
+	response, err := service.ShouldRateLimit(nil, request)
+	t.assert.Equal(
+		&pb.RateLimitResponse{
+			OverallCode: pb.RateLimitResponse_OVER_LIMIT,
+			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+				{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
 				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: nil, LimitRemaining: 0},
 			}},
 		response)


### PR DESCRIPTION
### Test Plan:

Env: internal dynamic swimlane

For all tests:
* Login.ashx rate limit rule is set to 0rps for both CDN/Direct connections with each rule having shadow mode set to true.
* Authorization header rate limit rule has no shadow mode rule set (default of false) and is set to 0 rps 

/Login.ashx was used for all requests to test that both rate limits are evaluated, and that if a non shadow mode enabled rule is overlimit that the entire request returns a 429, unless global shadow mode is enabled.

* Global off
  * With authorization header 5req = 5 429s + 5 prom rate limit hits
  * Without authorization header 5req = 5 200s + 5 prom shadow hits
* Global on 
  * With authorization header 5req = 5 200s + 5 prometheus shadow hits
  * Without authorization header  5req = 5 200s + 5 prom shadow hits
#### Example rule
```yaml
domain: envoy
descriptors:
#Detect user arriving via akamai and limit /Login.ashx requests
  - key: external_address
    descriptors:
    - key: destination_cluster
      value: davidw-1609956956431-us-west-2-devops_lsa
      descriptors:
      - key: header_match
        value: login
        descriptors:
        - key: header_match
          value: cdn
          rate_limit:
            unit: minute
            requests_per_unit: 0 
          shadowmode: true
```
### Changes to prometheus rate limiting metrics 

The original rate limiting metrics implementation will return a single key / value set for the entire request resulting in metrics like such
```shell
rate_limiting_shadow_requests{cluster="davidw-1610056619851-us-west-2-devops",descriptor_key="external_address_destination_cluster_header_match_header_match_authorization_header_header_match",descriptor_value="10.210.94.1_davidw-1610056619851-us-west-2-devops_ls_login_cdn_wrongva_integration",instance="10.30.50.107:8080",instance_id="i-005988dba216afa62",instance_type="t2.small",job="envoy_rate_limiting_config",limit="0",name="davidw-1610056619851-us-west-2-devops-devvm",role="rabbitmq,blackbox-exporter,envoy,grafana,iac-memcached_exporter,ossec,postgres-exporter,prometheus,push-gateway,redis_exporter,invoicing-middleware,data-import-middleware",swimlane="davidw-1610056619851-us-west-2-devops",unit="HOUR"}
``` 
* where both rules that had been exceeded are recorded as a single metric under
* key = `external_address_destination_cluster_header_match_header_match_authorization_header_header_match` with a 
* value =`10.210.94.1_davidw-1610056619851-us-west-2-devops_ls_login_cdn_wrongva_integration`

Comparing this to the new changes where each key corresponds with a single rule
```shell
rate_limiting_limited_requests{cluster="davidw-1609956956431-us-west-2-devops",descriptor_key="authorization_header_header_match",descriptor_value="wrongva_integration",instance="10.30.50.61:8080",instance_id="i-0598eaa7ce4d503eb",instance_type="t2.small",job="envoy_rate_limiting_config",limit="0",name="davidw-1609956956431-us-west-2-devops-devvm",role="rabbitmq,blackbox-exporter,envoy,grafana,iac-memcached_exporter,ossec,postgres-exporter,prometheus,push-gateway,redis_exporter,invoicing-middleware,data-import-middleware",swimlane="davidw-1609956956431-us-west-2-devops",unit="HOUR"}
```
* key = `authorization_header_header_match`
* value = `wrongva_integration`
 
```shell
rate_limiting_shadow_requests{cluster="davidw-1609956956431-us-west-2-devops",descriptor_key="external_address_destination_cluster_header_match_header_match",descriptor_value="10.210.94.1_davidw-1609956956431-us-west-2-devops_ls_login_cdn",instance="10.30.50.61:8080",instance_id="i-0598eaa7ce4d503eb",instance_type="t2.small",job="envoy_rate_limiting_config",limit="0",name="davidw-1609956956431-us-west-2-devops-devvm",role="rabbitmq,blackbox-exporter,envoy,grafana,iac-memcached_exporter,ossec,postgres-exporter,prometheus,push-gateway,redis_exporter,invoicing-middleware,data-import-middleware",swimlane="davidw-1609956956431-us-west-2-devops",unit="MINUTE"}
```
* key = `external_address_destination_cluster_header_match_header_match`
* value = `10.210.94.1_davidw-1609956956431-us-west-2-devops_ls_login_cdn`