### PR TITLE
SRE-5260 : export rate limiting config verification binary 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ COPY test test
 
 RUN go test -v -race github.com/replicon/ratelimit/...
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/replicon/ratelimit/src/service_cmd
-
+RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/replicon/ratelimit/src/service_cmd && \
+ CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit_config_check -ldflags="-w -s" -v github.com/replicon/ratelimit/src/config_check_cmd
 FROM alpine:3.11 AS final
 RUN apk --no-cache add ca-certificates
 COPY --from=build /go/bin/ratelimit /bin/ratelimit

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v g
 FROM alpine:3.11 AS final
 RUN apk --no-cache add ca-certificates
 COPY --from=build /go/bin/ratelimit /bin/ratelimit
+COPY --from=build /go/bin/ratelimit_config_check /bin/ratelimit_config_check
 ENTRYPOINT [ "/bin/ratelimit" ]


### PR DESCRIPTION
Test Plan:

Used branch build container on dynamic and confirmed that the new binary is present and executes as expected in both cases with and without a valid config. Returns 0 or 1 depending on if the config is valid or not.