### PR TITLE
SRE-5511 : remove 40char limit on entry value

### DIFF
--- a/src/util/util.go
+++ b/src/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -30,7 +29,7 @@ func ConvertToMetricsDescriptor(descriptorStatus *pb.RateLimitResponse_Descripto
 			descriptorValue.WriteString("_")
 		}
 		descriptorKey.WriteString(entry.Key)
-		descriptorValue.WriteString(fmt.Sprintf("%.*s", 40, entry.Value))
+		descriptorValue.WriteString(entry.Value)
 	}
 	if descriptorStatus.CurrentLimit != nil {
 		limit = strconv.FormatUint(uint64(descriptorStatus.CurrentLimit.RequestsPerUnit), 10)


### PR DESCRIPTION
Test Plan:

Deployed modified container onto a dynamic and lowered the authorization limit to 250req/hr. Then I made more then 250req with an authorization header that has over 40char and confirmed that it showed up in Grafana as a shadow hit [x]

<img width="798" alt="Screen Shot 2021-01-26 at 12 02 43" src="https://user-images.githubusercontent.com/33431229/105892148-aae57c00-5fce-11eb-87e6-51597161c437.png">
