### PR TITLE
SF-1144: Fix ratelimit codebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ redis-per-second.conf:
 bootstrap_redis_tls: redis.conf redis-per-second.conf
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
+	-reqexts SAN \
+    -extensions SAN \
+    -config <(cat /etc/ssl/openssl.cnf <(printf "\n[SAN]\nsubjectAltName=DNS:localhost")) \
     -keyout key.pem  -out cert.pem
 	cat key.pem cert.pem > private.pem
 	 cp cert.pem /usr/local/share/ca-certificates/redis-stunnel.crt

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ redis-per-second.conf:
 bootstrap_redis_tls: redis.conf redis-per-second.conf
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
-	-reqexts SAN \
+    -reqexts SAN \
     -extensions SAN \
     -config <(cat /etc/ssl/openssl.cnf <(printf "\n[SAN]\nsubjectAltName=DNS:localhost")) \
     -keyout key.pem  -out cert.pem

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      docker: 18
+      docker: latest
   build:
     commands:
       - chmod +x ci/*.sh

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,9 +1,6 @@
 version: 0.2
 
 phases:
-  install:
-    # runtime-versions:
-    #   docker: latest
   build:
     commands:
       - chmod +x ci/*.sh

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,8 +2,8 @@ version: 0.2
 
 phases:
   install:
-    runtime-versions:
-      docker: latest
+    # runtime-versions:
+    #   docker: latest
   build:
     commands:
       - chmod +x ci/*.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -23,7 +23,7 @@ setEnvs
 installLamp &
 docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
 for REGION in $APP_REPO_REGIONS; do
-  eval $(aws ecr get-login --region "$REGION" --no-include-email)
+  docker login --username AWS -p $(aws ecr get-login-password --region "$REGION") 434423891815.dkr.ecr.$REGION.amazonaws.com
 done
 
 set -e


### PR DESCRIPTION
For changes in ratelimit to take effect in [REAP](https://github.com/replicon/routing-envoy-application-proxy/blob/main/dependencies.json) or [IaC envoy](https://github.com/replicon/infrastructure-as-code/blob/master/envoy-server/inputs.tf#L218) additional PR's are required in the linked locations

Observing this error for codebuild:
`time="2024-02-28T07:09:39Z" level=error msg="error connecting to redis instance: x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0"
panic: x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`

Updated code to generate SAN extension as well.
