### PR TITLE
SC8-295: Use FIPS endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratelimit
 FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS final
 
 RUN yum install -y python3 && \
-  pip3 install ipaddress && \
+  pip3 install ipaddress pyyaml && \
   mkdir -p /srv/runtime_data/current/config && \
   mkdir -p /srv/runtime_data/current/validate_config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS build
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -17,10 +17,10 @@ RUN GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratel
 GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratelimit_config_check -ldflags="-w -s" -v github.com/replicon/ratelimit/src/config_check_cmd
 
 
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS final
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS final
 
 RUN yum install -y python3 && \
-  pip3 install ipaddress awscli && \
+  pip3 install ipaddress && \
   mkdir -p /srv/runtime_data/current/config && \
   mkdir -p /srv/runtime_data/current/validate_config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS build
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -17,7 +17,7 @@ RUN GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratel
 GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratelimit_config_check -ldflags="-w -s" -v github.com/replicon/ratelimit/src/config_check_cmd
 
 
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS final
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS final
 
 RUN yum install -y python3 && \
   pip3 install ipaddress pyyaml && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS build
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-12497-amazon-linux-2 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -17,7 +17,7 @@ RUN GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratel
 GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratelimit_config_check -ldflags="-w -s" -v github.com/replicon/ratelimit/src/config_check_cmd
 
 
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS final
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-12497-amazon-linux-2 AS final
 
 RUN yum install -y python3 && \
   pip3 install ipaddress pyyaml && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS build
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -17,7 +17,7 @@ RUN GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratel
 GOEXPERIMENT=boringcrypto CGO_ENABLED=1 GOOS=linux go build -o /go/bin/ratelimit_config_check -ldflags="-w -s" -v github.com/replicon/ratelimit/src/config_check_cmd
 
 
-FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11878-amazon-linux-2 AS final
+FROM 434423891815.dkr.ecr.us-east-1.amazonaws.com/machine-images/fips-base:m-11320-amazon-linux-2 AS final
 
 RUN yum install -y python3 && \
   pip3 install ipaddress && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+export AWS_USE_FIPS_ENDPOINT=${AWS_USE_FIPS_ENDPOINT}
+
+/usr/local/bin/aws --version
+
 export REDIS_AUTH=$(/usr/local/bin/aws ssm get-parameter --name ${REDIS_AUTH_SSM_PATH} --with-decryption --query 'Parameter.Value' --output text)
 
 nohup /sync_config.sh &

--- a/sync_config.sh
+++ b/sync_config.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+export AWS_USE_FIPS_ENDPOINT=${AWS_USE_FIPS_ENDPOINT}
+
+/bin/aws --version
+
 mkdir -p /extra_metrics
 /bin/python3 /metrics/main.py >/dev/null 2>&1 &
 

--- a/sync_config.sh
+++ b/sync_config.sh
@@ -2,7 +2,7 @@
 
 export AWS_USE_FIPS_ENDPOINT=${AWS_USE_FIPS_ENDPOINT}
 
-/bin/aws --version
+/usr/local/bin/aws --version
 
 mkdir -p /extra_metrics
 /bin/python3 /metrics/main.py >/dev/null 2>&1 &
@@ -11,7 +11,7 @@ cd /srv/runtime_data/current
 
 while true
 do
-  /bin/aws s3 sync --delete ${RLS_S3_PATH} data/
+  /usr/local/bin/aws s3 sync --delete ${RLS_S3_PATH} data/
 
   [ $? -eq 0 ] && /bin/python3 data/${RLS_SCRIPT_DIR}config-generator.py \
     --no-docker-container \


### PR DESCRIPTION
For changes in ratelimit to take effect in [REAP](https://github.com/replicon/routing-envoy-application-proxy/blob/main/dependencies.json) or [IaC envoy](https://github.com/replicon/infrastructure-as-code/blob/master/envoy-server/inputs.tf#L218) additional PR's are required in the linked locations

Test plan:
Deployed branch build on do2 and ran K6 tests against the swimlane and they passed.